### PR TITLE
add collection to model attrs during _prepareModel

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -264,6 +264,7 @@ extend(Collection.prototype, BackboneEvents, {
         if (!this.model) return attrs;
 
         if (this.isModel(attrs)) {
+            if (!attrs.collection) attrs.collection = this;
             return attrs;
         } else {
             options = options ? extend({}, options) : {};


### PR DESCRIPTION
This matches the [Backbone behavior](https://github.com/jashkenas/backbone/blob/master/backbone.js#L937).

This was causing [a failing test](https://github.com/AmpersandJS/ampersand-collection-rest-mixin/commit/e99422b317932bf88c6a49072b5dbcfe415b72d7) in the rest mixin when doing `create` with `wait:true`. Since that would cause `collection.add(model)` to not be called immediately, the model would never get a reference to the collection.
