### PR TITLE
Reversed sorting direction

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -216,16 +216,22 @@ extend(Collection.prototype, BackboneEvents, {
         options || (options = {});
 
         if (typeof this.comparator === 'string') {
+            var sortDirection = 1,
+                comparator = self.comparator;
+            if (comparator.indexOf('-') === 0){
+                sortDirection = -1;
+                comparator = comparator.slice(1);
+            }
             this.models.sort(function (left, right) {
                 if (left.get) {
-                    left = left.get(self.comparator);
-                    right = right.get(self.comparator);
+                    left = left.get(comparator);
+                    right = right.get(comparator);
                 } else {
-                    left = left[self.comparator];
-                    right = right[self.comparator];
+                    left = left[comparator];
+                    right = right[comparator];
                 }
-                if (left > right || left === void 0) return 1;
-                if (left < right || right === void 0) return -1;
+                if (left > right || left === void 0) return 1 * sortDirection;
+                if (left < right || right === void 0) return -1 * sortDirection;
                 return 0;
             });
         } else if (this.comparator.length === 1) {


### PR DESCRIPTION
Reverse the sorting direction of a collection by prepending the sorting attribute with a minus or dash sign. This has the minor incompatibility of not being able to sort on attributes that start with a dash, but such attributes would play poorly with Ampersand Model anyway.

Tests coming if this seems like a good idea, this is more a starting point for discussion
