### PR TITLE
Fix add with mainIndex and no model

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -78,7 +78,7 @@ extend(Collection.prototype, BackboneEvents, {
             } else if (targetProto.generateId) {
                 id = targetProto.generateId(attrs);
             } else {
-                id = attrs[targetProto.idAttribute || 'id'];
+                id = attrs[targetProto.idAttribute || this.mainIndex];
             }
 
             // If a duplicate is found, prevent it from being added and

--- a/test/main.js
+++ b/test/main.js
@@ -284,6 +284,18 @@ test('Bug 14. Should prevent duplicate items when using non-standard idAttribute
     t.end();
 });
 
+test('Should prevent duplicate items when using non-standard mainIndex without model', function (t) {
+    var C = Collection.extend({
+        mainIndex: '_id'
+    });
+    var c = new C([{_id: '2'}, {_id: '2'}, {_id: '2'}]);
+
+    t.equal(c.length, 1, 'should still be 1');
+    c.add({_id: '2'});
+    t.equal(c.length, 1, 'should still be 1 if added later');
+    t.end();
+});
+
 test('Bug 20. Should prevent duplicate items when using non-standard idAttribute', function (t) {
     var data = [{_id: '2'}];
     var Model = State.extend({


### PR DESCRIPTION
The `'id'` default is hardcoded twice. I was able to reuse an earlier test and verified it failed before making the easy fix.
