### PR TITLE
fixed index leaking and get/index for id:0 w/ tests

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -22,8 +22,6 @@ function Collection(models, options) {
 extend(Collection.prototype, BackboneEvents, {
     initialize: function () {},
 
-    indexes: [],
-
     isModel: function (model) {
         return this.model && model instanceof this.model;
     },
@@ -159,9 +157,9 @@ extend(Collection.prototype, BackboneEvents, {
     },
 
     get: function (query, indexName) {
-        if (!query) return;
+        if (query == null) return;
         var index = this._indexes[indexName || this.mainIndex];
-        return index[query] || index[query[this.mainIndex]] || this._indexes.cid[query.cid];
+        return (index && (index[query] || index[query[this.mainIndex]])) || this._indexes.cid[query.cid];
     },
 
     // Get the model at the given index.
@@ -247,7 +245,7 @@ extend(Collection.prototype, BackboneEvents, {
     // Private method to reset all internal state. Called when the collection
     // is first initialized or reset.
     _reset: function () {
-        var list = this.indexes || [];
+        var list = slice.call(this.indexes || []);
         var i = 0;
         list.push(this.mainIndex);
         list.push('cid');
@@ -284,8 +282,8 @@ extend(Collection.prototype, BackboneEvents, {
 
     _index: function (model) {
         for (var name in this._indexes) {
-            var indexVal = model[name] || (model.get && model.get(name));
-            if (indexVal) this._indexes[name][indexVal] = model;
+            var indexVal = model.hasOwnProperty(name) ? model[name] : (model.get && model.get(name));
+            if (indexVal != null) this._indexes[name][indexVal] = model;
         }
     },
 

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -76,7 +76,7 @@ extend(Collection.prototype, BackboneEvents, {
             } else if (targetProto.generateId) {
                 id = targetProto.generateId(attrs);
             } else {
-                id = attrs[targetProto.idAttribute || this.mainIndex];
+                id = attrs[this.mainIndex];
             }
 
             // If a duplicate is found, prevent it from being added and

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -276,7 +276,7 @@ extend(Collection.prototype, BackboneEvents, {
 
     _deIndex: function (model) {
         for (var name in this._indexes) {
-            delete this._indexes[name][model[name] || (model.get && model.get(name))];
+            delete this._indexes[name][model.hasOwnProperty(name) ? model[name] : (model.get && model.get(name))];
         }
     },
 

--- a/test/main.js
+++ b/test/main.js
@@ -414,3 +414,31 @@ test('should be able to get/remove a model with an idAttribute of 0', function (
 
     t.end();
 });
+
+
+test('should check for existing by mainIndex and not model.idAttribute', function (t) {
+    var C = Collection.extend({
+        mainIndex: 'name',
+        model: Stooge
+    });
+    var c = new C();
+    var moe = new Stooge({id: '0', name: 'moe'});
+    var curly = {id: '1', name: 'curly'};
+    c.add([moe, curly]);
+
+    t.notEqual(c.mainIndex, moe.idAttribute, 'mainIndex can be different than idAttribute');
+    t.equal(moe.idAttribute, 'id', 'default model attribute should be id');
+    t.equal(moe.getId(), '0', 'default model attribute should be id');
+    t.ok(c.get('curly'), 'should get model using mainIndex');
+    t.equal(c.get('moe'), moe, 'should get same model using mainIndex');
+
+    t.equal(c.length, 2, 'should be only 2 models');
+    c.add(curly);
+    t.equal(c.length, 2, 'should not add duplicate');
+    c.remove(moe);
+    t.equal(c.length, 1, 'should be able to remove model');
+    c.remove(curly);
+    t.equal(c.length, 0, 'should be able to remove model by property');
+
+    t.end();
+});

--- a/test/main.js
+++ b/test/main.js
@@ -390,7 +390,7 @@ test('Should not leak indexes between collections when indexes is undefined', fu
     t.end();
 });
 
-test('should be able to get a model with an idAttribute of 0', function (t) {
+test('should be able to get/remove a model with an idAttribute of 0', function (t) {
     var C = Collection.extend({
         mainIndex: 'id',
         indexes: ['username']
@@ -408,5 +408,9 @@ test('should be able to get a model with an idAttribute of 0', function (t) {
     t.ok(c.get(0, 'id'), 'should get by id:0');
     t.ok(c.get(0), 'should get by id:0');
     t.equal(moe, c.get(0));
+
+    c.remove(0);
+    t.notOk(c.get(0), 'should remove by id:0');
+
     t.end();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -365,3 +365,48 @@ test('add with validate:true enforces validation', function (t) {
 
     t.end();
 });
+
+test('Should not leak indexes between collections when indexes is undefined', function (t) {
+    var data = [{id: 4, name: 'me'}];
+    var C = Collection.extend({
+        mainIndex: 'id'
+    });
+
+    var D = Collection.extend({
+        mainIndex: 'name'
+    });
+    var c = new C();
+    var d = new D();
+
+    c.reset(data);
+    d.reset(data);
+
+    t.ok(c.get(4), 'should get by mainIndex');
+    t.ok(d.get('me'), 'should get by mainIndex');
+    // t.ok(d.get(4, 'id'), 'should get by secondary index');
+    t.notOk(c.get('me', 'name'), 'should throw and error for invalid index');
+    t.notOk(d.get(4, 'me'), 'should throw and error for invalid index');
+    t.equal(d.get('me'), d.at(0), 'should get the same model by different indexes');
+    t.end();
+});
+
+test('should be able to get a model with an idAttribute of 0', function (t) {
+    var C = Collection.extend({
+        mainIndex: 'id',
+        indexes: ['username']
+    });
+    var c = new C();
+    var moe = {id: 0, username: 'moe'};
+    var curly = {id: 1, username: 'curly'};
+    c.add([moe, curly]);
+
+    // t.equal(moe, c.get('moe', 'username'));
+    t.ok(c.get(1), 'should get by id:1');
+    t.ok(c.get('curly', 'username'), 'should get by secondary index');
+    t.ok(c.get('moe', 'username'), 'should get by secondary index');
+    t.ok(c._indexes.id[0], 'should get by id:0');
+    t.ok(c.get(0, 'id'), 'should get by id:0');
+    t.ok(c.get(0), 'should get by id:0');
+    t.equal(moe, c.get(0));
+    t.end();
+});


### PR DESCRIPTION
Tracked down a bug that was causing models with an attribute value of 0 to not be indexed or accessible with `get(0)`. 

Also found that indexes were leaking into the root `this.index` when not overwritten so fixed that too.