### PR TITLE
allow getting a model by cid value

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -161,7 +161,7 @@ extend(Collection.prototype, BackboneEvents, {
     get: function (query, indexName) {
         if (!query) return;
         var index = this._indexes[indexName || this.mainIndex];
-        return index[query] || index[query[this.mainIndex]] || this._indexes.cid[query.cid];
+        return index[query] || index[query[this.mainIndex]] || this._indexes.cid[query] || this._indexes.cid[query.cid];
     },
 
     // Get the model at the given index.

--- a/test/main.js
+++ b/test/main.js
@@ -365,3 +365,22 @@ test('add with validate:true enforces validation', function (t) {
 
     t.end();
 });
+
+test('get can be used with cid value or cid obj', function (t) {
+    t.plan(2);
+
+    var C = Collection.extend({
+        model: State.extend({
+            props: {
+                id: 'number'
+            }
+        })
+    });
+    var collection = new C([{id: 1}, {id: 2}, {id: 3}]);
+    var first = collection.at(0);
+
+    t.equal(1, collection.get(first.cid).id);
+    t.equal(1, collection.get({cid: first.cid}).id);
+
+    t.end();
+});


### PR DESCRIPTION
Ran into this issue when porting some backbone code to ampersand.

Trying to get a model by its cid value was always returning `undefined`.