### PR TITLE
Reindexing model on a change event

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -276,16 +276,30 @@ extend(Collection.prototype, BackboneEvents, {
         }
     },
 
-    _deIndex: function (model) {
-        for (var name in this._indexes) {
-            delete this._indexes[name][model[name] || (model.get && model.get(name))];
+    _deIndex: function (model, attribute, value) {
+        if (undefined !== attribute) {
+            if (undefined === this._indexes[attribute]) throw new Error('Given attribute is not an index');
+            delete this._indexes[attribute][value];
+            return;
+        }
+        // Not a specific attribute
+        for (attribute in this._indexes) {
+            delete this._indexes[attribute][model[attribute] || (model.get && model.get(attribute))];
         }
     },
 
-    _index: function (model) {
-        for (var name in this._indexes) {
-            var indexVal = model[name] || (model.get && model.get(name));
-            if (indexVal) this._indexes[name][indexVal] = model;
+    _index: function (model, attribute) {
+        var indexVal;
+        if (undefined !== attribute) {
+            if (undefined === this._indexes[attribute]) throw new Error('Given attribute is not an index');
+            indexVal = model[attribute] || (model.get && model.get(attribute));
+            if (indexVal) this._indexes[attribute][indexVal] = model;
+            return;
+        }
+        // Not a specific attribute
+        for (attribute in this._indexes) {
+            indexVal = model[attribute] || (model.get && model.get(attribute));
+            if (indexVal) this._indexes[attribute][indexVal] = model;
         }
     },
 
@@ -309,8 +323,8 @@ extend(Collection.prototype, BackboneEvents, {
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
         if (model && event === 'change' && this._indexes[attribute]) {
-			this._deIndex(model.previousAttributes());
-			this._index(model);
+			this._deIndex(model, attribute, model.previousAttributes()[attribute]);
+			this._index(model, attribute);
         }
         this.trigger.apply(this, arguments);
     }

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -323,8 +323,8 @@ extend(Collection.prototype, BackboneEvents, {
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
         if (model && event === 'change' && this._indexes[attribute]) {
-			this._deIndex(model, attribute, model.previousAttributes()[attribute]);
-			this._index(model, attribute);
+            this._deIndex(model, attribute, model.previousAttributes()[attribute]);
+            this._index(model, attribute);
         }
         this.trigger.apply(this, arguments);
     }

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -304,11 +304,13 @@ extend(Collection.prototype, BackboneEvents, {
     },
 
     _onModelEvent: function (event, model, collection, options) {
+        var attribute = event.split(':')[1];
+        event = event.split(':')[0];
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
-        if (model && event === 'change:' + this.mainIndex) {
-            this._deIndex(model);
-            this._index(model);
+        if (model && event === 'change' && this._indexes[attribute]) {
+			this._deIndex(model.previousAttributes());
+			this._index(model);
         }
         this.trigger.apply(this, arguments);
     }

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -277,20 +277,22 @@ extend(Collection.prototype, BackboneEvents, {
     },
 
     _deIndex: function (model, attribute, value) {
-        if (undefined !== attribute) {
+        var indexVal;
+        if (attribute !== undefined) {
             if (undefined === this._indexes[attribute]) throw new Error('Given attribute is not an index');
             delete this._indexes[attribute][value];
             return;
         }
         // Not a specific attribute
         for (attribute in this._indexes) {
-            delete this._indexes[attribute][model[attribute] || (model.get && model.get(attribute))];
+            indexVal = model[attribute] || (model.get && model.get(attribute));
+            delete this._indexes[attribute][indexVal];
         }
     },
 
     _index: function (model, attribute) {
         var indexVal;
-        if (undefined !== attribute) {
+        if (attribute !== undefined) {
             if (undefined === this._indexes[attribute]) throw new Error('Given attribute is not an index');
             indexVal = model[attribute] || (model.get && model.get(attribute));
             if (indexVal) this._indexes[attribute][indexVal] = model;

--- a/test/main.js
+++ b/test/main.js
@@ -386,7 +386,7 @@ test('get can be used with cid value or cid obj', function (t) {
 });
 
 test('Bug 45. Should update indexes if an indexed attribute of a model change', function (t) {
-    t.plan(8);
+    t.plan(9);
 
     var C = Collection.extend({
         model: Stooge,
@@ -410,5 +410,8 @@ test('Bug 45. Should update indexes if an indexed attribute of a model change', 
     model.unset('name');
     t.equal('2', collection.get('2').id, 'should find model with mainIndex after unset other index');
     t.equal(undefined, collection.get('moe', 'name'), 'should not find model with old value of other index after unset this attribute');
+
+    model.name = 'curly';
+    t.equal('2', collection.get('curly', 'name').id, 'should find model with new value of other index after unset/set');
     t.end();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -384,3 +384,31 @@ test('get can be used with cid value or cid obj', function (t) {
 
     t.end();
 });
+
+test('Bug 45. Should update indexes if an indexed attribute of a model change', function (t) {
+    t.plan(8);
+
+    var C = Collection.extend({
+        model: Stooge,
+        indexes: ['name']
+    });
+
+    var model = new Stooge({id: '1', name: 'moe'});
+    var collection = new C(model);
+
+    t.equal('1', collection.get('1').id, 'should find model with mainindex');
+    t.equal('1', collection.get('moe', 'name').id, 'should find model with other index');
+
+    model.id = '2';
+    t.equal('2', collection.get('2').id, 'should find model with new value of mainIndex');
+    t.equal(undefined, collection.get('1'), 'should not find model with old value of mainIndex');
+
+    model.name = 'larry';
+    t.equal('2', collection.get('larry', 'name').id, 'should find model with new value of other index');
+    t.equal(undefined, collection.get('moe', 'name'), 'should not find model with old value of other index');
+
+    model.unset('name');
+    t.equal('2', collection.get('2').id, 'should find model with mainIndex after unset other index');
+    t.equal(undefined, collection.get('moe', 'name'), 'should not find model with old value of other index after unset this attribute');
+    t.end();
+});


### PR DESCRIPTION
deIndex and Index have now optionals parameters in order to handle specific attribute.
All indexes are updated rather than mainIndex only.
Issue #45 