### PR TITLE
Allow for getting model using get(0)

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -159,7 +159,7 @@ extend(Collection.prototype, BackboneEvents, {
     },
 
     get: function (query, indexName) {
-        if (!query) return;
+        if (query == null) return;
         var index = this._indexes[indexName || this.mainIndex];
         return index[query] || index[query[this.mainIndex]] || this._indexes.cid[query] || this._indexes.cid[query.cid];
     },
@@ -285,7 +285,7 @@ extend(Collection.prototype, BackboneEvents, {
     _index: function (model) {
         for (var name in this._indexes) {
             var indexVal = model[name] || (model.get && model.get(name));
-            if (indexVal) this._indexes[name][indexVal] = model;
+            if (indexVal != null) this._indexes[name][indexVal] = model;
         }
     },
 

--- a/test/main.js
+++ b/test/main.js
@@ -384,3 +384,20 @@ test('get can be used with cid value or cid obj', function (t) {
 
     t.end();
 });
+
+test('get can use 0 as a query argument', function (t) {
+    t.plan(1);
+
+    var C = Collection.extend({
+        model: State.extend({
+            props: {
+                id: 'number'
+            }
+        })
+    });
+    var collection = new C([{id: 0}, {id: 1}, {id: 2}]);
+
+    t.equal(0, collection.get(0).id);
+
+    t.end();
+});


### PR DESCRIPTION
Ignore only `null` and `undefined` while allowing `0` to be used as an `id` value.

Fixes https://github.com/AmpersandJS/ampersand-collection/issues/49