### PR TITLE
replace native `bind` with amp-bind

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -1,6 +1,7 @@
 var BackboneEvents = require('backbone-events-standalone');
 var classExtend = require('ampersand-class-extend');
 var isArray = require('is-array');
+var bind = require('amp-bind');
 var extend = require('extend-object');
 var slice = [].slice;
 
@@ -237,7 +238,7 @@ extend(Collection.prototype, BackboneEvents, {
                 return 0;
             });
         } else {
-            this.models.sort(this.comparator.bind(this));
+            this.models.sort(bind(this.comparator,this));
         }
 
         if (!options.silent) this.trigger('sort', this, options);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/ampersandjs/ampersand-collection/issues"
   },
   "dependencies": {
+    "amp-bind": "^1.0.1",
     "ampersand-class-extend": "^1.0.0",
     "backbone-events-standalone": "0.2.2",
     "extend-object": "^1.0.0",

--- a/test/main.js
+++ b/test/main.js
@@ -165,6 +165,22 @@ test('comparator as standard 2 arg sort function', function (t) {
     t.end();
 });
 
+test('comparator as 2 arg has ref to "this"', function(t){
+    var boundCollection;
+    var Coll = Collection.extend({
+        comparator: function (m1, m2) {
+            boundCollection = this;
+            return 0;
+        }
+    });
+    var c = new Coll();
+    var moe = new Stooge({name: 'moe', id: '1'});
+    var larry = new Stooge({name: 'larry', id: '2'});
+    c.add([moe, larry]);
+    t.equal(c,boundCollection);
+    t.end();
+});
+
 test('should store reference to parent instance if passed', function (t) {
     var parent = {};
     var c = new Collection([], {parent: parent});


### PR DESCRIPTION
A small change to make life easier for those using phantom.js with ampersand collections.  Fixes #52.  Threw in a test just to make sure I didn't break anything.  It passed before the change as well of course.  