### PR TITLE
Fix regression introduced by 1.4.3, fixes #56

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -319,11 +319,12 @@ extend(Collection.prototype, AmpersandEvents, {
     },
 
     _onModelEvent: function (event, model, collection, options) {
+        var eventName = event.split(':')[0];
         var attribute = event.split(':')[1];
-        event = event.split(':')[0];
-        if ((event === 'add' || event === 'remove') && collection !== this) return;
-        if (event === 'destroy') this.remove(model, options);
-        if (model && event === 'change' && this._indexes[attribute]) {
+
+        if ((eventName === 'add' || eventName === 'remove') && collection !== this) return;
+        if (eventName === 'destroy') this.remove(model, options);
+        if (model && eventName === 'change' && attribute && this._indexes[attribute]) {
             this._deIndex(model, attribute, model.previousAttributes()[attribute]);
             this._index(model, attribute);
         }

--- a/test/main.js
+++ b/test/main.js
@@ -504,3 +504,21 @@ test('Bug 45. Should update indexes if an indexed attribute of a model change', 
     t.equal('2', collection.get('curly', 'name').id, 'should find model with new value of other index after unset/set');
     t.end();
 });
+
+test('Collection should rethrow change events on a model', function (t) {
+    t.plan(2);
+    var C = Collection.extend({
+        model: Stooge,
+        indexes: ['name']
+    });
+
+    var model = new Stooge({id: '1', name: 'moe'});
+    var collection = new C(model);
+
+    collection.on('change:name', function (m, newName) {
+        t.equal(m, model);
+        t.equal(newName, 'shmoe');
+    });
+
+    model.name = 'shmoe';
+});


### PR DESCRIPTION
It turns out, reusing argument names as variables is dangerous
if you then go on to use `arguments`.

Take this example:

```js
function x (a) {
    a = 10;
    console.log(arguments);
}

x('foo');
```

One might think that this would print `[ 'foo' ]`.
One would be wrong.