### PR TITLE
Docs: constructor/initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ var Library = AmpersandCollection.extend({
 ```
 
 
-### constructor/initialize `new AmpersandCollection([models, [options]])`
+### constructor/initialize `new AmpersandCollection([models [, options]])`
 
 When creating an `AmpersandCollection`, you may choose to pass in the initial array of **`models`**. The collection's [`comparator`](#comparator) may be included as an option. If you define an **`initialize`** function, it will be invoked when the collection is created, with **`models`** and **`options`** as arguments. There are a couple of options that, if provided, are attached to the collection directly: `model`, `comparator` and `parent`. 
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ var Library = AmpersandCollection.extend({
 ```
 
 
-### constructor/initialize `new AmpersandCollection([models], [options])`
+### constructor/initialize `new AmpersandCollection([models, [options]])`
 
-When creating an `AmpersandCollection`, you may choose to pass in the initial array of **`models`**. The collection's [`comparator`](#comparator) may be included as an option. If you define an **`initialize`** function, it will be invoked when the collection is created. There are a couple of options that, if provided, are attached to the collection directly: `model`, `comparator` and `parent`.
+When creating an `AmpersandCollection`, you may choose to pass in the initial array of **`models`**. The collection's [`comparator`](#comparator) may be included as an option. If you define an **`initialize`** function, it will be invoked when the collection is created, with **`models`** and **`options`** as arguments. There are a couple of options that, if provided, are attached to the collection directly: `model`, `comparator` and `parent`. 
 
 ```javascript
 var people = new AmpersandCollection([{ name: 'phil' }, { name: 'bob' }, { name: 'jane' }], {


### PR DESCRIPTION
Hi @lukekarrys and others,

ref this [issue](https://github.com/AmpersandJS/ampersand-rest-collection/issues/26) on `ampersand-rest-collection`. TL:DR: constructor arguments are not independently optional, but the docs make it seem that way.

Updated the `constructor/initialize` part in the docs to match more with the actual contructor-code.

NOTE! This is my first PR ever, so feedback welcome!

Cheers