### PR TITLE
Fix deopt caused by nonlocal forIn in indices

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -285,9 +285,9 @@ assign(Collection.prototype, AmpersandEvents, {
             return;
         }
         // Not a specific attribute
-        for (attribute in this._indexes) {
-            indexVal = model.hasOwnProperty(attribute) ? model[attribute] : (model.get && model.get(attribute));
-            delete this._indexes[attribute][indexVal];
+        for (var indexAttr in this._indexes) {
+            indexVal = model.hasOwnProperty(indexAttr) ? model[indexAttr] : (model.get && model.get(indexAttr));
+            delete this._indexes[indexAttr][indexVal];
         }
     },
 
@@ -300,9 +300,9 @@ assign(Collection.prototype, AmpersandEvents, {
             return;
         }
         // Not a specific attribute
-        for (attribute in this._indexes) {
-            indexVal = model.hasOwnProperty(attribute) ? model[attribute] : (model.get && model.get(attribute));
-            if (indexVal != null) this._indexes[attribute][indexVal] = model;
+        for (var indexAttr in this._indexes) {
+            indexVal = model.hasOwnProperty(indexAttr) ? model[indexAttr] : (model.get && model.get(indexAttr));
+            if (indexVal != null) this._indexes[indexAttr][indexVal] = model;
         }
     },
 

--- a/benchmark/massCreate.js
+++ b/benchmark/massCreate.js
@@ -1,0 +1,65 @@
+var State = require('ampersand-state');
+var Collection = require('../ampersand-collection');
+
+var SomeModel = State.extend({
+  derived: {
+    foo: {
+      deps: ['a', 'b'],
+      fn: function derived () {
+        return this.a + this.b;
+      }
+    }
+  }
+});
+
+var CustomCollection = Collection.extend({
+  model: SomeModel,
+  mainIndex: 'a',
+  indexes: ['b'],
+  isModel: function(model) {
+    return model instanceof SomeModel;
+  }
+});
+
+var data = new Array(1000);
+for (var i = 0; i < 1000; i++) {
+  data[i] = new SomeModel({a: i, b: i * 2})
+}
+
+//Function that contains the pattern to be inspected
+function benchFn() {
+  var coll = new CustomCollection(data);
+}
+
+function printStatus(fn) {
+    switch(%GetOptimizationStatus(fn)) {
+        case 1: console.log("Function is optimized"); break;
+        case 2: console.log("Function is not optimized"); break;
+        case 3: console.log("Function is always optimized"); break;
+        case 4: console.log("Function is never optimized"); break;
+        case 6: console.log("Function is maybe deoptimized"); break;
+    }
+}
+
+//Fill type-info
+benchFn();
+// 2 calls are needed to go from uninitialized -> pre-monomorphic -> monomorphic
+benchFn();
+benchFn();
+benchFn();
+benchFn();
+benchFn();
+
+%OptimizeFunctionOnNextCall(benchFn);
+//The next call
+benchFn();
+
+//Check
+printStatus(benchFn);
+
+
+console.time('createCollection');
+for (var i = 0; i < 1000;i++) {
+  benchFn();
+}
+console.timeEnd('createCollection');


### PR DESCRIPTION
Noticed this sucking up a good amount of time in profiling; easy fix so why not throw it in.

For reference:

https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#5-for-in

![screen shot 2016-01-05 at 6 15 06 pm](https://cloud.githubusercontent.com/assets/1197375/12131471/7fd38554-b3d8-11e5-9904-6beafea78d5e.jpg)
