### PR TITLE
only call model.trigger if it is a function

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -146,7 +146,7 @@ assign(Collection.prototype, AmpersandEvents, {
         if (!options.silent) {
             for (i = 0, length = toAdd.length; i < length; i++) {
                 model = toAdd[i];
-                if (model.trigger) {
+                if (model.trigger && typeof model.trigger === 'function') {
                     model.trigger('add', model, this, options);
                 } else {
                     this.trigger('add', model, this, options);


### PR DESCRIPTION
I'm running into an error when `model.trigger` is a called but it isn't a function. My model contains arbitrary data and makes use of the `extraProperties: 'allow'` option.

In my case (when I haven't defined a model on the handler, my user has provided data with the `trigger` property defined), the desired behavior is to fall through to the else case.

Happy to make desired changes! :)
