### PR TITLE
update testing framework, fix isCollection bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules
+*.log
+.zuulrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,22 @@
+sudo: false
 language: node_js
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+node_js: '4'
+cache:
+  directories: node_modules
+before_script: npm prune
+branches:
+  except: /^v\d+\.\d+\.\d+$/
+notifications:
+  webhooks:
+    urls: https://webhooks.gitter.im/e/df4440290bd89d941fb4
+    on_success: change
+    on_failure: always
+    on_start: false
+  email: false
+script: npm run test-ci
+addons:
+  sauce_connect: true
+env:
+  global:
+  - secure: eo5dz5pxCSKO56Q/sjk+YDH0MshPoYXV9UzDF18go9VF7ei4mRC/SajDEt+OFfERbLufxzSs7gRU/LHUCqqyX3KlJv9Dn8FAqJqfmPmDnDWehnpVdlZydGsXLCvA2ZacAHL1ylnkLgRE8KswYIQwajdTdqpv+5CwEJS94yyJslM=
+  - secure: cKy3ImmuIvdz1vge2ZB/Bw0hcGLZLZpRnU/ChoRaa5eRH1V1mkuvvwvJlH/UGeXM3312TCJ/LsFYDIYlGlZVoRTPykIuO/ZZ4URO+vSiYa2VElIbVn8phdYaiugsEoxRD9p1s+mnjZ79FSyMnEoYLbf46OqvCI9G3XXknH2V/Ig=

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,14 @@
+ui: tape
+browsers:
+  - name: chrome
+    version: latest
+  - name: firefox
+    version: latest
+  - name: safari
+    version: latest
+  - name: ie
+    version: 9..latest
+  - name: iphone
+    version: latest
+  - name: android
+    version: latest

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ It does not require underscore or jQuery, but instead makes it easy to extend wi
 Part of the [Ampersand.js toolkit](http://ampersandjs.com) for building clientside applications.
 <!-- endhide -->
 
-<!-- starthide -->
-## browser support
-
-[![browser support](https://ci.testling.com/ampersandjs/ampersand-collection.png)
-](https://ci.testling.com/ampersandjs/ampersand-collection)
-<!-- endhide -->
-
 ## Installation
 
 ```

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -348,7 +348,9 @@ Object.defineProperties(Collection.prototype, {
         }
     },
     isCollection: {
-        value: true
+        get: function () {
+            return true;
+        }
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "devDependencies": {
     "ampersand-state": "^4.4.5",
+    "phantomjs": "^1.9.19",
     "precommit-hook": "0.x.x",
-    "run-browser": "^1.3.1",
-    "tap-spec": "^0.2.1",
-    "tape": "2.x.x"
+    "tape": "2.x.x",
+    "zuul": "^3.9.0"
   },
   "homepage": "https://github.com/ampersandjs/ampersand-collection",
   "keywords": [
@@ -35,27 +35,12 @@
     "url": "git://github.com/ampersandjs/ampersand-collection"
   },
   "scripts": {
-    "start": "run-browser test/*",
-    "test": "node test/main.js | tap-spec",
+    "start": "zuul --local -- test/main.js",
+    "test": "zuul --phantom -- test/main.js",
+    "test-ci": "zuul -- test/main.js",
     "preversion": "git checkout master && git pull && npm ls",
     "publish-patch": "npm run preversion && npm version patch && git push origin master --tags && npm publish",
     "publish-minor": "npm run preversion && npm version minor && git push origin master --tags && npm publish",
     "publish-major": "npm run preversion && npm version major && git push origin master --tags && npm publish"
-  },
-  "testling": {
-    "files": "test/*.js",
-    "browsers": [
-      "ie/9..latest",
-      "firefox/17..latest",
-      "firefox/nightly",
-      "chrome/22..latest",
-      "chrome/canary",
-      "opera/12..latest",
-      "opera/next",
-      "safari/5.1..latest",
-      "ipad/6.0..latest",
-      "iphone/6.0..latest",
-      "android-browser/4.2..latest"
-    ]
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -275,7 +275,12 @@ test('Serialize/toJSON method', function (t) {
 test('Ensure `isCollection` exists and is immutable', function (t) {
     var c = new Collection();
     t.ok(c.isCollection);
-    c.isCollection = false;
+    try {
+      c.isCollection = false;
+    } catch (e) {
+      //It's ok if this throws, the property only has a setter
+      //and some browsers (i.e. phantomjs) error on this
+    }
     t.ok(c.isCollection);
     t.end();
 });


### PR DESCRIPTION
Switch fully to zuul
Add saucelabs config
Use node LTS and npm 2 for building

See discussion that led to this here: AmpersandJS/ampersand-filtered-subcollection#26

Setting isCollection as a `value` property meant that
some browsers (phantomjs at least) were allowing it to be
overwritten. Changed to a proper getter only.

This will warrant a new release, unlike most of the other PRs that are updating testing, as there was a change in the code itself.