### PR TITLE
Reindex after replacing a model

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -123,9 +123,9 @@ assign(Collection.prototype, AmpersandEvents, {
             }
             if (toRemove.length) this.remove(toRemove, options);
 
-            // Add indexes again to make sure they were not removed above
-            if (toAdd.length) {
-                this._index(toAdd[0]);
+            // Add indexes again to make sure they were not removed above.
+            for (i = 0, length = toAdd.length; i < length; i++) {
+                this._index(toAdd[i]);
             }
         }
 

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -122,6 +122,11 @@ assign(Collection.prototype, AmpersandEvents, {
                 if (!modelMap[model.cid || model[this.mainIndex]]) toRemove.push(model);
             }
             if (toRemove.length) this.remove(toRemove, options);
+
+            // Add indexes again to make sure they were not removed above
+            if (toAdd.length) {
+                this._index(toAdd[0]);
+            }
         }
 
         // See if sorting is needed, update `length` and splice in new models.

--- a/test/main.js
+++ b/test/main.js
@@ -550,3 +550,24 @@ test('Collection should rethrow change events on a model', function (t) {
 
     model.name = 'shmoe';
 });
+
+test('indexes: should reindex on a `set` of a model with same index secondary index value (#84)', function (t) {
+    var FooCollection = Collection.extend({
+        indexes: ['foo', 'see']
+    });
+
+    var obj = {id: '47', foo: 'bar', see: 'saw'};
+    var obj2 = {id: '48', foo: 'bar', see: 'food'};
+    var obj3 = {id: '49', foo: 'far', see: 'saw'};
+
+    var c = new FooCollection([obj]);
+
+    t.equal(c.get('bar', 'foo'), obj);
+
+    c.set([obj2, obj3]);
+
+    t.equal(c.get('bar', 'foo'), obj2);
+    t.equal(c.get('saw', 'see'), obj3);
+
+    t.end();
+});


### PR DESCRIPTION
When replacing an existing model with a new model on `set() ` which both had the same value for an indexed attribute, the new model was removed from the index.