### PR TITLE
Model with id "undefined" returned by collection.get(obj)

### DIFF
--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -166,9 +166,22 @@ assign(Collection.prototype, AmpersandEvents, {
 
     get: function (query, indexName) {
         if (query == null) return;
-        var index = this._indexes[indexName || this.mainIndex];
-        if(index && index[query[this.mainIndex]] && query[this.mainIndex] === undefined) return;
-        return (index && (index[query] || index[query[this.mainIndex]])) || this._indexes.cid[query] || this._indexes.cid[query.cid];
+
+        var collectionMainIndex = this.mainIndex;
+        var index = this._indexes[indexName || collectionMainIndex];
+
+        return (
+            (
+                index && (
+                    index[query] || (
+                        query[collectionMainIndex] !== undefined &&
+                        index[query[collectionMainIndex]]
+                    )
+                )
+            ) ||
+            this._indexes.cid[query] ||
+            this._indexes.cid[query.cid]
+        );
     },
 
     // Get the model at the given index.

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -4,7 +4,6 @@ var isArray = require('lodash/isArray');
 var bind = require('lodash/bind');
 var assign = require('lodash/assign');
 var slice = [].slice;
-var _ = require('lodash');
 
 function Collection(models, options) {
     options || (options = {});
@@ -168,8 +167,7 @@ assign(Collection.prototype, AmpersandEvents, {
     get: function (query, indexName) {
         if (query == null) return;
         var index = this._indexes[indexName || this.mainIndex];
-        if(index && index[query[this.mainIndex]] && query[this.mainIndex] === undefined)
-        return;
+        if(index && index[query[this.mainIndex]] && query[this.mainIndex] === undefined) return;
         return (index && (index[query] || index[query[this.mainIndex]])) || this._indexes.cid[query] || this._indexes.cid[query.cid];
     },
 

--- a/ampersand-collection.js
+++ b/ampersand-collection.js
@@ -4,6 +4,7 @@ var isArray = require('lodash/isArray');
 var bind = require('lodash/bind');
 var assign = require('lodash/assign');
 var slice = [].slice;
+var _ = require('lodash');
 
 function Collection(models, options) {
     options || (options = {});
@@ -167,6 +168,8 @@ assign(Collection.prototype, AmpersandEvents, {
     get: function (query, indexName) {
         if (query == null) return;
         var index = this._indexes[indexName || this.mainIndex];
+        if(index && index[query[this.mainIndex]] && query[this.mainIndex] === undefined)
+        return;
         return (index && (index[query] || index[query[this.mainIndex]])) || this._indexes.cid[query] || this._indexes.cid[query.cid];
     },
 

--- a/test/main.js
+++ b/test/main.js
@@ -571,3 +571,11 @@ test('indexes: should reindex on a `set` of a model with same index secondary in
 
     t.end();
 });
+
+test('Model with "undefined" id.', function (t) {
+    var c = new Collection();
+    c.model = Stooge;
+    c.set([{name: 'moe', id: 'undefined'}, {name: 'larry', id: '2'}, {name: 'curly', id: ''}]);
+    t.equal(c.length, 3, 'should have 3 stooges');
+    t.end();
+});


### PR DESCRIPTION
@dhritzkiv  The Collection::get method has this odd behaviour when the collection contains a model with the id "undefined": collection.get(obj) will return that model whenever obj.id is undefined. An odd edge case, I know, but I ran into this in a production application... among other things, it means that

new Collection([{id: 'undefined'}, {id: 'foo'}, {id: 'bar'}])
will create a collection with length 1.

What was wrong with the definition of get, which explicitly checked for this case?
return index && (index[query] || index[query[this.mainIndex]])